### PR TITLE
Project refreshing works now also offline

### DIFF
--- a/tmc-plugin-intellij/src/main/java/fi.helsinki.cs.tmc.intellij/services/CourseAndExerciseManager.java
+++ b/tmc-plugin-intellij/src/main/java/fi.helsinki.cs.tmc.intellij/services/CourseAndExerciseManager.java
@@ -119,8 +119,12 @@ public class CourseAndExerciseManager {
         getExerciseDatabase().setCourses(courses);
     }
 
-    private static void removeExercisesNotFoundFromLocalDirectories(List<Exercise> exercises, String courseName) {
-        List<String> exerciseNamesThroughDirectories = getExerciseNamesThroughDirectories(courseName);
+    private static void removeExercisesNotFoundFromLocalDirectories(List<Exercise> exercises,
+                                                                    String courseName) {
+
+        List<String> exerciseNamesThroughDirectories =
+                getExerciseNamesThroughDirectories(courseName);
+
         Iterator<Exercise> iterator = exercises.iterator();
 
         while (iterator.hasNext()) {

--- a/tmc-plugin-intellij/src/main/java/fi.helsinki.cs.tmc.intellij/services/CourseAndExerciseManager.java
+++ b/tmc-plugin-intellij/src/main/java/fi.helsinki.cs.tmc.intellij/services/CourseAndExerciseManager.java
@@ -11,6 +11,7 @@ import fi.helsinki.cs.tmc.intellij.ui.projectlist.ProjectListManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -103,12 +104,42 @@ public class CourseAndExerciseManager {
             ErrorMessageService error = new ErrorMessageService();
             error.showMessage(exception);
 
-            /*Messages.showErrorDialog(new ObjectFinder().findCurrentProject(),
-                    exception.getMessage()
-                    + " " + exception.toString(), "Error");
-            */
+            refreshCoursesOffline();
         }
     }
+
+    private static void refreshCoursesOffline() {
+        Map<String, List<Exercise>> courses = getExerciseDatabase().getCourses();
+
+        for (String courseName : courses.keySet()) {
+            List<Exercise> exercises = courses.get(courseName);
+
+            removeExercisesNotFoundFromLocalDirectories(exercises, courseName);
+        }
+        getExerciseDatabase().setCourses(courses);
+    }
+
+    private static void removeExercisesNotFoundFromLocalDirectories(List<Exercise> exercises, String courseName) {
+        List<String> exerciseNamesThroughDirectories = getExerciseNamesThroughDirectories(courseName);
+        Iterator<Exercise> iterator = exercises.iterator();
+
+        while (iterator.hasNext()) {
+            Exercise exercise = iterator.next();
+
+            if (!exerciseNamesThroughDirectories.contains(exercise.getName())) {
+                iterator.remove();
+            }
+        }
+    }
+
+    private static List<String> getExerciseNamesThroughDirectories(String courseName) {
+        return new ObjectFinder().listAllDownloadedExercises(courseName);
+    }
+
+    private static ExerciseDatabase getExerciseDatabase() {
+        return PersistentExerciseDatabase.getInstance().getExerciseDatabase();
+    }
+
     /*
     private void updateDatabase(Course course, List<Exercise> exercises) {
         database.put(course.getName(), exercises);
@@ -118,15 +149,14 @@ public class CourseAndExerciseManager {
     public static void updateSingleCourse(String courseName, CheckForExistingExercises checker,
                                           ObjectFinder finder,
                                           SettingsTmc settings) {
-        boolean isNewCourse = PersistentExerciseDatabase.getInstance()
-                .getExerciseDatabase().getCourses().get(courseName) == null;
+
+        boolean isNewCourse = getExerciseDatabase().getCourses().get(courseName) == null;
         Course course = finder.findCourseByName(courseName, TmcCoreHolder.get());
 
         List<Exercise> existing = (ArrayList<Exercise>) checker
                 .getListOfDownloadedExercises(course.getExercises(), settings);
 
-        PersistentExerciseDatabase.getInstance().getExerciseDatabase()
-                .getCourses().put(courseName, existing);
+        getExerciseDatabase().getCourses().put(courseName, existing);
 
         if (isNewCourse) {
             ProjectListManager.refreshAllCourses();

--- a/tmc-plugin-intellij/src/main/java/fi.helsinki.cs.tmc.intellij/services/ExerciseDatabase.java
+++ b/tmc-plugin-intellij/src/main/java/fi.helsinki.cs.tmc.intellij/services/ExerciseDatabase.java
@@ -16,7 +16,7 @@ public class ExerciseDatabase implements Serializable {
     private Map<String, List<Exercise>> courses;
 
     public ExerciseDatabase() {
-        this.courses =  new HashMap();
+        courses =  new HashMap();
     }
 
     public Map<String, List<Exercise>> getCourses() {
@@ -26,4 +26,5 @@ public class ExerciseDatabase implements Serializable {
     public void setCourses(Map<String, List<Exercise>> courses) {
         this.courses = courses;
     }
+
 }

--- a/tmc-plugin-intellij/src/main/java/fi.helsinki.cs.tmc.intellij/services/ObjectFinder.java
+++ b/tmc-plugin-intellij/src/main/java/fi.helsinki.cs.tmc.intellij/services/ObjectFinder.java
@@ -94,7 +94,7 @@ public class ObjectFinder {
                 fileNames.add(getExerciseName(exerciseCourse));
             }
         } catch (IOException ex)  {
-            ex.printStackTrace();
+//            ex.printStackTrace();
         }
         Collections.sort(fileNames);
         return fileNames;


### PR DESCRIPTION
If the user is offline and tries to refresh the project in the project view, the plugin checks if the user has made any external changes to the local directories containing the exercises. If the user has removed anything, the project database is changed as needed so that the removed exercises aren't seen on the project view anymore.
