### PR TITLE
Handle test compilation/execution errors

### DIFF
--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/actions/StartupEvent.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/actions/StartupEvent.java
@@ -49,7 +49,7 @@ public class StartupEvent implements StartupActivity {
                         "Running TMC startup actions.", project, false, false, false);
 
         CoreProgressObserver observer = new CoreProgressObserver(progressWindow);
-        new ErrorMessageService().showInfoNotification("The Test My Code Plugin for Intellij is in BETA and"
+        new ErrorMessageService().showInfoBalloon("The Test My Code Plugin for Intellij is in BETA and"
                 + " may not work properly. Use at your own risk. ");
 
 

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/actions/buttonactions/TmcSettingsAction.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/actions/buttonactions/TmcSettingsAction.java
@@ -1,6 +1,5 @@
 package fi.helsinki.cs.tmc.intellij.actions.buttonactions;
 
-
 import fi.helsinki.cs.tmc.intellij.ui.settings.SettingsWindow;
 
 import com.intellij.openapi.actionSystem.AnAction;

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/holders/ExerciseDatabaseManager.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/holders/ExerciseDatabaseManager.java
@@ -1,6 +1,5 @@
 package fi.helsinki.cs.tmc.intellij.holders;
 
-
 import fi.helsinki.cs.tmc.intellij.services.persistence.ExerciseDatabase;
 import fi.helsinki.cs.tmc.intellij.services.persistence.PersistentExerciseDatabase;
 

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/holders/TmcSettingsManager.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/holders/TmcSettingsManager.java
@@ -1,6 +1,5 @@
 package fi.helsinki.cs.tmc.intellij.holders;
 
-
 import fi.helsinki.cs.tmc.intellij.io.SettingsTmc;
 import fi.helsinki.cs.tmc.intellij.services.persistence.PersistentTmcSettings;
 

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/importexercise/ProjectFromSourcesBuilderImplModified.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/importexercise/ProjectFromSourcesBuilderImplModified.java
@@ -107,7 +107,7 @@ public class ProjectFromSourcesBuilderImplModified {
             }
         } catch (Exception e) {
             logger.warn(e.getMessage());
-            new ErrorMessageService().showMessage(e, "Error adding module to project", true);
+            new ErrorMessageService().showErrorMessage(e, "Error adding module to project", true);
         }
 
         final Map<ModuleDescriptor, Module> descriptorToModuleMap = new HashMap<>();
@@ -146,7 +146,7 @@ public class ProjectFromSourcesBuilderImplModified {
             }
         } catch (Exception e) {
             logger.warn(e.getMessage());
-            new ErrorMessageService().showMessage(e, "Error adding module to project", true);
+            new ErrorMessageService().showErrorMessage(e, "Error adding module to project", true);
         }
         logger.info("ending commit in ProjectFromSourcesBuilderImplModified");
         //return result;

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/io/ProjectOpener.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/io/ProjectOpener.java
@@ -55,7 +55,7 @@ public class ProjectOpener {
                             exception,
                             exception.getStackTrace());
                     new ErrorMessageService()
-                            .showMessage(
+                            .showErrorMessage(
                                     exception, "Could not open project from path. " + path, true);
                 }
             }

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/ObjectFinder.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/ObjectFinder.java
@@ -1,6 +1,5 @@
 package fi.helsinki.cs.tmc.intellij.services;
 
-
 import fi.helsinki.cs.tmc.core.TmcCore;
 import fi.helsinki.cs.tmc.core.domain.Course;
 import fi.helsinki.cs.tmc.core.domain.Exercise;

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/ObjectFinder.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/ObjectFinder.java
@@ -63,11 +63,11 @@ public class ObjectFinder {
         } catch (TmcCoreException e) {
             logger.warn(
                     "Could not find course {}. @ObjectFinder", courseName, e, e.getStackTrace());
-            new ErrorMessageService().showMessage(e, false);
+            new ErrorMessageService().showHumanReadableErrorMessage(e, false);
         } catch (Exception e) {
             logger.warn(
                     "Could not find course {}. @ObjectFinder", courseName, e, e.getStackTrace());
-            new ErrorMessageService().showMessage(e, "Could not find course. " + courseName, true);
+            new ErrorMessageService().showErrorMessage(e, "Could not find course. " + courseName, true);
         }
         if (courses == null) {
             return null;
@@ -94,14 +94,14 @@ public class ObjectFinder {
                             courseName,
                             exception,
                             exception.getStackTrace());
-                    new ErrorMessageService().showMessage(exception, false);
+                    new ErrorMessageService().showHumanReadableErrorMessage(exception, false);
                 } catch (Exception e) {
                     logger.warn(
                             "Could not find course {}. @ObjectFinder",
                             courseName,
                             e,
                             e.getStackTrace());
-                    new ErrorMessageService().showMessage(e, "Could not find course.", true);
+                    new ErrorMessageService().showErrorMessage(e, "Could not find course.", true);
                 }
             }
         }

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/PasteService.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/PasteService.java
@@ -88,7 +88,7 @@ public class PasteService {
                                         exception,
                                         exception.getStackTrace());
                                 new ErrorMessageService()
-                                        .showMessage(
+                                        .showErrorMessage(
                                                 exception,
                                                 "Error while uploading to TMC Pastebin.",
                                                 true);
@@ -101,7 +101,7 @@ public class PasteService {
         logger.info("Handling the exception from uploading failure. @PasteService");
         closeWindowIfExists();
 
-        new ErrorMessageService().showMessage(exception, false);
+        new ErrorMessageService().showHumanReadableErrorMessage(exception, false);
         exception.printStackTrace();
     }
 

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/PathResolver.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/PathResolver.java
@@ -1,6 +1,5 @@
 package fi.helsinki.cs.tmc.intellij.services;
 
-
 import fi.helsinki.cs.tmc.core.domain.Course;
 import fi.helsinki.cs.tmc.core.domain.Exercise;
 import fi.helsinki.cs.tmc.intellij.holders.TmcCoreHolder;

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/TestRunningService.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/TestRunningService.java
@@ -1,6 +1,5 @@
 package fi.helsinki.cs.tmc.intellij.services;
 
-import com.intellij.notification.NotificationType;
 import fi.helsinki.cs.tmc.core.domain.Exercise;
 import fi.helsinki.cs.tmc.intellij.actions.buttonactions.UploadExerciseAction;
 import fi.helsinki.cs.tmc.intellij.holders.TmcCoreHolder;
@@ -11,6 +10,7 @@ import fi.helsinki.cs.tmc.langs.domain.RunResult;
 import fi.helsinki.cs.tmc.langs.domain.SpecialLogs;
 import fi.helsinki.cs.tmc.langs.domain.TestResult;
 
+import com.intellij.notification.NotificationType;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.util.ProgressWindow;
 import com.intellij.openapi.project.Project;

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/TestRunningService.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/TestRunningService.java
@@ -44,7 +44,7 @@ public class TestRunningService {
                     exercise,
                     exception);
             new ErrorMessageService()
-                    .showMessage(
+                    .showErrorMessage(
                             exception, "Running tests failed, exercise was not recognized", true);
         }
     }
@@ -68,7 +68,7 @@ public class TestRunningService {
                     } catch (Exception exception) {
                         logger.warn("Could not run tests. @TestRunningService", exception);
                         new ErrorMessageService()
-                                .showMessage(exception, "Running tests failed!", true);
+                                .showErrorMessage(exception, "Running tests failed!", true);
                     }
                 },
                 project,

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/TestRunningService.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/TestRunningService.java
@@ -1,5 +1,6 @@
 package fi.helsinki.cs.tmc.intellij.services;
 
+import com.intellij.notification.NotificationType;
 import fi.helsinki.cs.tmc.core.domain.Exercise;
 import fi.helsinki.cs.tmc.intellij.actions.buttonactions.UploadExerciseAction;
 import fi.helsinki.cs.tmc.intellij.holders.TmcCoreHolder;
@@ -7,6 +8,7 @@ import fi.helsinki.cs.tmc.intellij.io.CoreProgressObserver;
 import fi.helsinki.cs.tmc.intellij.services.errors.ErrorMessageService;
 import fi.helsinki.cs.tmc.intellij.ui.testresults.TestResultPanelFactory;
 import fi.helsinki.cs.tmc.langs.domain.RunResult;
+import fi.helsinki.cs.tmc.langs.domain.SpecialLogs;
 import fi.helsinki.cs.tmc.langs.domain.TestResult;
 
 import com.intellij.openapi.application.ApplicationManager;
@@ -17,6 +19,8 @@ import com.intellij.openapi.wm.ToolWindowManager;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
 
 public class TestRunningService {
 
@@ -59,21 +63,48 @@ public class TestRunningService {
         logger.info("Preparing thread for running tests. @TestRunningService");
         threadingService.runWithNotification(
                 () -> {
-                    RunResult result = null;
+                    RunResult result;
                     try {
                         result = TmcCoreHolder.get().runTests(observer, exercise).call();
-                        RunResult finalResult = result;
-                        showTestResult(finalResult);
-                        checkIfAllTestsPassed(finalResult, project);
                     } catch (Exception exception) {
                         logger.warn("Could not run tests. @TestRunningService", exception);
                         new ErrorMessageService()
                                 .showErrorMessage(exception, "Running tests failed!", true);
+                        return;
                     }
+
+                    if (isErrorStatus(result.status)) {
+                        String stdout = getLog(result, SpecialLogs.STDOUT);
+                        String stderr = getLog(result, SpecialLogs.STDERR);
+
+                        String message = (result.status == RunResult.Status.COMPILE_FAILED)
+                                ? "Something went wrong while compiling the code. See details below."
+                                : "Something went wrong while running the tests. See details below.";
+
+                        new ErrorMessageService().showPopupWithDetails(
+                                message,
+                                "Test Error",
+                                stderr + System.lineSeparator() + stdout,
+                                NotificationType.ERROR
+                        );
+                        return;
+                    }
+
+                    showTestResult(result);
+                    checkIfAllTestsPassed(result, project);
                 },
                 project,
                 window);
         displayTestWindow(finder);
+    }
+
+    private String getLog(RunResult result, String log) {
+        return new String(result.logs.get(log), StandardCharsets.UTF_8);
+    }
+
+    private boolean isErrorStatus(RunResult.Status status) {
+        return status == RunResult.Status.COMPILE_FAILED
+            || status == RunResult.Status.GENERIC_ERROR;
     }
 
     private void checkIfAllTestsPassed(RunResult finalResult, Project project) {

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/errors/ErrorMessageService.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/errors/ErrorMessageService.java
@@ -50,6 +50,27 @@ public class ErrorMessageService {
         });
     }
 
+    public void showPopupWithDetails(String message,
+                                     String title,
+                                     String details,
+                                     NotificationType notificationType) {
+        Project currentProject = new ObjectFinder().findCurrentProject();
+        Icon icon = iconForNotificationType(notificationType);
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            Messages.showDialog(
+                    currentProject,
+                    message,
+                    title,
+                    details,
+                    new String[] { Messages.OK_BUTTON },
+                    0,
+                    0,
+                    icon
+            );
+        });
+    }
+
     /**
      * Shows a human readable error message to the user as a popup or a notification balloon.
      *

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/errors/ErrorMessageService.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/errors/ErrorMessageService.java
@@ -36,11 +36,11 @@ public class ErrorMessageService {
 
     private static final Logger logger = LoggerFactory.getLogger(ErrorMessageService.class);
 
-    public void showInfoNotification(String message) {
+    public void showInfoBalloon(String message) {
         showBalloonNotification(message, NotificationType.INFORMATION);
     }
 
-    public void downloadErrorMessage(Course course) {
+    public void showExercisesAreUpToDate(Course course) {
         ApplicationManager.getApplication().invokeLater(() -> {
             Messages.showMessageDialog(
                     "All exercises for " + course.toString() + " are up to date.",
@@ -56,7 +56,7 @@ public class ErrorMessageService {
      * @param coreException The cause of the error.
      * @param showAsPopup if the error message will be a pop up or not.
      */
-    public void showMessage(TmcCoreException coreException, boolean showAsPopup) {
+    public void showHumanReadableErrorMessage(TmcCoreException coreException, boolean showAsPopup) {
         logger.info("Showing human readable TmcCoreException. {} @ErrorMessageService", coreException);
         PresentableErrorMessage content = PresentableErrorMessage.forTmcException(coreException);
         showNotification(content.getMessage(), content.getMessageType(), showAsPopup);
@@ -69,9 +69,9 @@ public class ErrorMessageService {
      * @param errorDescription Additional description of the error.
      * @param showAsPopup if the error message will be a pop up or not.
      */
-    public void showMessage(Exception exception,
-                            String errorDescription,
-                            boolean showAsPopup) {
+    public void showErrorMessage(Exception exception,
+                                 String errorDescription,
+                                 boolean showAsPopup) {
         logger.info("Showing Exception. {} @ErrorMessageService", exception);
         String message = exception + ". \n" + errorDescription;
         showNotification(message, NotificationType.ERROR, showAsPopup);

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/errors/ErrorMessageService.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/errors/ErrorMessageService.java
@@ -1,9 +1,7 @@
 package fi.helsinki.cs.tmc.intellij.services.errors;
 
-
 import fi.helsinki.cs.tmc.core.domain.Course;
 import fi.helsinki.cs.tmc.core.exceptions.TmcCoreException;
-import fi.helsinki.cs.tmc.intellij.holders.TmcSettingsManager;
 import fi.helsinki.cs.tmc.intellij.services.ObjectFinder;
 
 import com.intellij.notification.Notification;
@@ -11,15 +9,14 @@ import com.intellij.notification.NotificationDisplayType;
 import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
-
 import com.intellij.openapi.application.ApplicationManager;
-
 import com.intellij.openapi.project.Project;
-
 import com.intellij.openapi.ui.Messages;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.swing.Icon;
 
 /**
  * Pops up user friendly warnings and specified error messages. For example pops up an error message
@@ -28,228 +25,93 @@ import org.slf4j.LoggerFactory;
  */
 public class ErrorMessageService {
 
+    /**
+     * Notification group used by IntelliJ to group TMC notifications.
+     */
+    public static final NotificationGroup TMC_NOTIFICATION = new NotificationGroup(
+            "TMC Error Messages",
+            NotificationDisplayType.STICKY_BALLOON,
+            true
+    );
+
     private static final Logger logger = LoggerFactory.getLogger(ErrorMessageService.class);
 
-    private String notifyAboutCourseServerAddressAndInternet() {
-        logger.info(
-                "Picking up Error message from notifyAboutCourseServerAddressAndInternet. "
-                        + "@ErrorMessageService");
-        return "Failed to download courses\n"
-                + "Check that you have the correct course and server address\n"
-                + "and you are connected to Internet";
-    }
-
-    /**
-     * Error message, if TMC username or password are not initialized.
-     *
-     * @param exception The cause of an error.
-     * @return String. Error message that will be shown to the user.
-     */
-    private String notifyAboutUsernamePasswordAndServerAddress(TmcCoreException exception) {
-        logger.info(
-                "Picking up Error message from notifyAboutUsernamePasswordAndServerAddress. "
-                        + "@ErrorMessageService");
-        return errorCode(exception)
-                + "Seems like you don't have your TMC settings initialized. \n"
-                + "Set up your username, password and TMC server address.";
-    }
-
-    /**
-     * Error message, if TMC server address has not been initialized.
-     *
-     * @param exception The cause of an error.
-     * @return String. Error message that will be shown to the user.
-     */
-    private String notifyAboutEmptyServerAddress(TmcCoreException exception) {
-        logger.info(
-                "Picking up Error message from notifyAboutEmptyServerAddress. "
-                        + "@ErrorMessageService");
-        return errorCode(exception)
-                + "You need to set up TMC server address "
-                + "to be able to download and submit exercises.";
-    }
-
-    private String notifyAboutFailedSubmissionAttempt(TmcCoreException exception) {
-        logger.info(
-                "Picking up Error message from notifyAboutFailedSubmissionAttempt. "
-                        + "@ErrorMessageService");
-        return "Failed to establish connection to the server" + "\n Check your Internet connection";
-    }
-
-    /**
-     * Error message, if TMC username or password is incorrect.
-     *
-     * @param exception The cause of an error.
-     * @return String. Error message that will be shown to the user.
-     */
-    private String notifyAboutIncorrectUsernameOrPassword(TmcCoreException exception) {
-        logger.info(
-                "Error message from notifyAboutIncorrectUsernameOrPassword. "
-                        + "@ErrorMessageService");
-        return errorCode(exception) + "TMC Username or Password incorrect.";
-    }
-
-    /**
-     * Error message, prints out the cause of the current exception.
-     *
-     * @param exception The cause of an error.
-     * @return String. Error message that will be shown to the user.
-     */
-    private String errorCode(TmcCoreException exception) {
-        logger.info(
-                "Adding Error cause to the Error message shown to the user. "
-                        + "@ErrorMessageService");
-        return exception.getCause().getMessage() + ". \n";
-    }
-
-    /**
-     * Error message, prints out the cause of the current exception.
-     *
-     * @param exception The cause of an error.
-     * @return String. Error message that will be shown to the user.
-     */
-    private String errorCode(Exception exception, String str) {
-        logger.info(
-                "Adding exception to the Error message shown to the user. "
-                        + "@ErrorMessageService");
-        return exception + ". \n" + str;
-    }
-
-    /**
-     * Creates a new notification group TMC_NOTIFICATION for TMC notifications to the notification
-     * board.
-     */
-    public static final NotificationGroup TMC_NOTIFICATION =
-            new NotificationGroup(
-                    "TMC Error Messages", NotificationDisplayType.STICKY_BALLOON, true);
-
-    /**
-     * Generates a balloon notification or a popup message.
-     *
-     * @param str Notification message.
-     * @param type The type of notification to be shown.
-     * @param bool If the error message will be a popup or not.
-     */
-    private void initializeNotification(final String str, NotificationType type, boolean bool) {
-        logger.info(
-                "Working on what kind of error notification will be "
-                        + "shown to the user. @ErrorMessageService");
-        final Project projects = new ObjectFinder().findCurrentProject();
-        if (bool) {
-            logger.info(
-                    "Interrupting Error message popup. Location middle of the screen. "
-                            + "@ErrorMessageService");
-            Messages.showMessageDialog(projects, str, "", Messages.getErrorIcon());
-        } else {
-            logger.info(
-                    "User friendly STICKY_BALLOON notification."
-                            + " Location right corner. @ErrorMessageService");
-            Notification notification = TMC_NOTIFICATION.createNotification(str, type);
-            Notifications.Bus.notify(notification, projects);
-        }
-    }
-
-    /**
-     * Selects the error message method to be called.
-     *
-     * @param exception The cause of an error.
-     * @param bool If the error message will be a popup or not.
-     */
-    private void selectMessage(TmcCoreException exception, boolean bool) {
-        logger.info("Selecting the error message method to be called. @ErrorMessageService");
-        String str = exception.getCause().getMessage();
-        NotificationType type = NotificationType.WARNING;
-        if (str.contains("Download failed") || str.contains("404") || str.contains("500")) {
-            initializeNotification(notifyAboutCourseServerAddressAndInternet(), type, bool);
-        } else if (!TmcSettingsManager.get().userDataExists()) {
-            initializeNotification(
-                    notifyAboutUsernamePasswordAndServerAddress(exception), type, bool);
-        } else if (str.contains("401")) {
-            initializeNotification(
-                    notifyAboutIncorrectUsernameOrPassword(exception),
-                    NotificationType.ERROR,
-                    bool);
-        } else if (exception.getMessage().contains("Failed to fetch courses from the server")
-                || exception.getMessage().contains("Failed to compress project")) {
-            initializeNotification(notifyAboutFailedSubmissionAttempt(exception), type, bool);
-        } else if (TmcSettingsManager.get().getServerAddress().isEmpty()) {
-            initializeNotification(notifyAboutEmptyServerAddress(exception), type, bool);
-        } else {
-            initializeNotification(errorCode(exception), NotificationType.ERROR, bool);
-            exception.printStackTrace();
-        }
-    }
-
-    /**
-     * Controls which error message will be shown to the user. If the parameter bool is true, the
-     * message will be shown as a popup. If not, then it will be shown at the side.
-     *
-     * @param exception The cause of an error.
-     * @param bool if the error message will be a pop up or not.
-     */
-    public void showMessage(final TmcCoreException exception, final boolean bool) {
-        logger.info("Starting to handle TmcCoreException." + " {} @ErrorMessageService", exception);
-        if (bool) {
-            logger.info("Redirecting to selectMessage. @ErrorMessageService");
-            selectMessage(exception, bool);
-        } else {
-            logger.info("Executing on pooled thread. @ErrorMessageService");
-            ApplicationManager.getApplication()
-                    .invokeLater(
-                            () -> {
-                                logger.info(
-                                        "Redirecting to selectMessage . @ErrorMessageService");
-                                selectMessage(exception, bool);
-                            });
-        }
-    }
-
-    /**
-     * Redirecting the error handling to another showMessage method with boolean parameter.
-     *
-     * @param exception The cause of an error.
-     * @param errorMessage Error message.
-     */
-    public void showMessage(final Exception exception, final String errorMessage) {
-        logger.info(
-                "Redirecting Error message handling to showMessage(Exception, "
-                        + "String, boolean), boolean as false. @ErrorMessageService");
-        showMessage(exception, errorMessage, false);
-    }
-
-    /**
-     * Controls which error message will be shown to the user.
-     *
-     * @param exception The cause of an error.
-     * @param errorMessage Error message.
-     */
-    public void showMessage(
-            final Exception exception, final String errorMessage, final boolean bool) {
-        logger.info("Starting to handle Exception " + " {} . @ErrorMessageService", exception);
-        ApplicationManager.getApplication()
-                .invokeLater(
-                        () -> {
-                            initializeNotification(
-                                    errorCode(exception, errorMessage),
-                                    NotificationType.ERROR,
-                                    bool);
-                            exception.printStackTrace();
-                        });
+    public void showInfoNotification(String message) {
+        showBalloonNotification(message, NotificationType.INFORMATION);
     }
 
     public void downloadErrorMessage(Course course) {
-        //final Project projects = new ObjectFinder().findCurrentProject();
-        ApplicationManager.getApplication()
-                .invokeLater(
-                        () -> Messages.showMessageDialog(
-                                "All exercises for "
-                                        + course.toString()
-                                        + " are up to date.",
-                                "All Exercises Are up to Date.",
-                                Messages.getInformationIcon()));
+        ApplicationManager.getApplication().invokeLater(() -> {
+            Messages.showMessageDialog(
+                    "All exercises for " + course.toString() + " are up to date.",
+                    "All Exercises Are up to Date.",
+                    Messages.getInformationIcon()
+            );
+        });
     }
 
-    public void showInfoNotification(final String message) {
-        initializeNotification(message, NotificationType.INFORMATION, false);
+    /**
+     * Shows a human readable error message to the user as a popup or a notification balloon.
+     *
+     * @param coreException The cause of the error.
+     * @param showAsPopup if the error message will be a pop up or not.
+     */
+    public void showMessage(TmcCoreException coreException, boolean showAsPopup) {
+        logger.info("Showing human readable TmcCoreException. {} @ErrorMessageService", coreException);
+        PresentableErrorMessage content = PresentableErrorMessage.forTmcException(coreException);
+        showNotification(content.getMessage(), content.getMessageType(), showAsPopup);
+    }
+
+    /**
+     * Shows an error message to the user as a popup or a notification balloon.
+     *
+     * @param exception The cause of the error, prepended to the description.
+     * @param errorDescription Additional description of the error.
+     * @param showAsPopup if the error message will be a pop up or not.
+     */
+    public void showMessage(Exception exception,
+                            String errorDescription,
+                            boolean showAsPopup) {
+        logger.info("Showing Exception. {} @ErrorMessageService", exception);
+        String message = exception + ". \n" + errorDescription;
+        showNotification(message, NotificationType.ERROR, showAsPopup);
+    }
+
+    private void showNotification(String message, NotificationType type, boolean showAsPopup) {
+        if (showAsPopup) {
+            showPopup(message, type);
+        } else {
+            showBalloonNotification(message, type);
+        }
+    }
+
+    private void showBalloonNotification(String message, NotificationType type) {
+        Notification notification = TMC_NOTIFICATION.createNotification(message, type);
+        Project currentProject = new ObjectFinder().findCurrentProject();
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            Notifications.Bus.notify(notification, currentProject);
+        });
+    }
+
+    private void showPopup(String message, NotificationType notificationType) {
+        Project currentProject = new ObjectFinder().findCurrentProject();
+        Icon icon = iconForNotificationType(notificationType);
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            Messages.showMessageDialog(currentProject, message, "", icon);
+        });
+    }
+
+    private Icon iconForNotificationType(NotificationType type) {
+        if (type == NotificationType.WARNING) {
+            return Messages.getWarningIcon();
+        } else if (type == NotificationType.ERROR) {
+            return Messages.getErrorIcon();
+        } else if (type == NotificationType.INFORMATION) {
+            return Messages.getInformationIcon();
+        } else {
+            return Messages.getErrorIcon();
+        }
     }
 }

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/errors/PresentableErrorMessage.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/errors/PresentableErrorMessage.java
@@ -1,0 +1,80 @@
+package fi.helsinki.cs.tmc.intellij.services.errors;
+
+import com.intellij.notification.NotificationType;
+import fi.helsinki.cs.tmc.core.exceptions.FailedHttpResponseException;
+import fi.helsinki.cs.tmc.core.exceptions.TmcCoreException;
+import fi.helsinki.cs.tmc.intellij.holders.TmcSettingsManager;
+
+class PresentableErrorMessage {
+    private String message;
+    private NotificationType messageType;
+
+    private PresentableErrorMessage(String message, NotificationType messageType) {
+        this.message = message;
+        this.messageType = messageType;
+    }
+
+    String getMessage() {
+        return message;
+    }
+
+    NotificationType getMessageType() {
+        return messageType;
+    }
+
+    /**
+     * Generates a human readable error message for a {@link TmcCoreException} and decides the
+     * error's severity.
+     */
+    static PresentableErrorMessage forTmcException(TmcCoreException exception) {
+        Throwable cause = exception.getCause();
+        String causeMessage = cause.getMessage();
+
+        String shownMessage;
+        NotificationType type = NotificationType.WARNING;
+
+        if (causeMessage.contains("Download failed") || causeMessage.contains("404") || causeMessage.contains("500")) {
+            shownMessage = notifyAboutCourseServerAddressAndInternet();
+        } else if (!TmcSettingsManager.get().userDataExists()) {
+            shownMessage = notifyAboutUsernamePasswordAndServerAddress(causeMessage);
+        } else if (causeMessage.contains("401")) {
+            shownMessage = notifyAboutIncorrectUsernameOrPassword(causeMessage);
+            type = NotificationType.ERROR;
+        } else if (exception.getMessage().contains("Failed to fetch courses from the server")
+                || exception.getMessage().contains("Failed to compress project")) {
+            shownMessage = notifyAboutFailedSubmissionAttempt();
+        } else if (TmcSettingsManager.get().getServerAddress().isEmpty()) {
+            shownMessage = notifyAboutEmptyServerAddress(causeMessage);
+        } else {
+            shownMessage = exception.getCause().getMessage();
+            type = NotificationType.ERROR;
+        }
+
+        return new PresentableErrorMessage(shownMessage, type);
+    }
+
+    private static String notifyAboutCourseServerAddressAndInternet() {
+        return "Failed to download courses\n"
+                + "Check that you have the correct course and server address\n"
+                + "and you are connected to Internet";
+    }
+
+    private static String notifyAboutUsernamePasswordAndServerAddress(String causeMessage) {
+        return causeMessage
+                + ".\nSeems like you don't have your TMC settings initialized. \n"
+                + "Set up your username, password and TMC server address.";
+    }
+
+    private static String notifyAboutEmptyServerAddress(String causeMessage) {
+        return causeMessage + ".\nYou need to set up TMC server address "
+                + "to be able to download and submit exercises.";
+    }
+
+    private static String notifyAboutFailedSubmissionAttempt() {
+        return "Failed to establish connection to the server.\n Check your Internet connection";
+    }
+
+    private static String notifyAboutIncorrectUsernameOrPassword(String causeMessage) {
+        return causeMessage + ".\nTMC Username or Password incorrect.";
+    }
+}

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/errors/PresentableErrorMessage.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/errors/PresentableErrorMessage.java
@@ -1,9 +1,9 @@
 package fi.helsinki.cs.tmc.intellij.services.errors;
 
-import com.intellij.notification.NotificationType;
-import fi.helsinki.cs.tmc.core.exceptions.FailedHttpResponseException;
 import fi.helsinki.cs.tmc.core.exceptions.TmcCoreException;
 import fi.helsinki.cs.tmc.intellij.holders.TmcSettingsManager;
+
+import com.intellij.notification.NotificationType;
 
 class PresentableErrorMessage {
     private String message;

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/exercises/CourseAndExerciseManager.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/exercises/CourseAndExerciseManager.java
@@ -74,7 +74,7 @@ public class CourseAndExerciseManager {
                     exception,
                     exception.getStackTrace());
             ErrorMessageService error = new ErrorMessageService();
-            error.showMessage(exception, "Could not find the course.", false);
+            error.showErrorMessage(exception, "Could not find the course.", false);
         }
         return null;
     }
@@ -108,7 +108,7 @@ public class CourseAndExerciseManager {
                     exception,
                     exception.getStackTrace());
             ErrorMessageService error = new ErrorMessageService();
-            error.showMessage(exception, false);
+            error.showHumanReadableErrorMessage(exception, false);
             refreshCoursesOffline();
         } catch (Exception exception) {
             logger.warn(
@@ -116,7 +116,7 @@ public class CourseAndExerciseManager {
                     exception,
                     exception.getStackTrace());
             ErrorMessageService error = new ErrorMessageService();
-            error.showMessage(exception, "Failed to fetch courses from tmc core.", false);
+            error.showErrorMessage(exception, "Failed to fetch courses from tmc core.", false);
             refreshCoursesOffline();
         }
     }
@@ -139,7 +139,7 @@ public class CourseAndExerciseManager {
                     exception,
                     exception.getStackTrace());
             new ErrorMessageService()
-                    .showMessage(exception, "Failed to initiate database", true);
+                    .showErrorMessage(exception, "Failed to initiate database", true);
         }
     }
 

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/exercises/ExerciseDownloadingService.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/exercises/ExerciseDownloadingService.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -89,7 +88,7 @@ public class ExerciseDownloadingService {
                         exercises = notCompletedExercises(exercises);
                     }
                     if (exercises == null || exercises.size() == 0) {
-                        new ErrorMessageService().downloadErrorMessage(course);
+                        new ErrorMessageService().showExercisesAreUpToDate(course);
                         return;
                     }
                     new DownloadListWindow().showDownloadableExercises(exercises);
@@ -101,7 +100,7 @@ public class ExerciseDownloadingService {
                             except,
                             except.getStackTrace());
                     new ErrorMessageService()
-                            .showMessage(
+                            .showErrorMessage(
                                     except,
                                     "You need to select a course to be able to download.",
                                     true);
@@ -137,7 +136,7 @@ public class ExerciseDownloadingService {
                 } catch (Exception exception) {
                     logger.info("Failed to download exercises. @ExerciseDownloadingService");
                     new ErrorMessageService()
-                            .showMessage(exception, "Failed to download exercises.", true);
+                            .showErrorMessage(exception, "Failed to download exercises.", true);
                 }
 
                 createThreadForRefreshingExerciseList();
@@ -158,14 +157,14 @@ public class ExerciseDownloadingService {
         List<Exercise> exercises = course.getExercises();
         exercises = checker.clean(exercises, settings);
         if (exercises == null || exercises.size() == 0) {
-            new ErrorMessageService().downloadErrorMessage(course);
+            new ErrorMessageService().showExercisesAreUpToDate(course);
             return true;
         }
         try {
             openFirstExercise(exercises, core, observer);
         } catch (Exception exception) {
             logger.info("Failed to download exercises. @ExerciseDownloadingService");
-            new ErrorMessageService().showMessage(exception, "Failed to download exercises.", true);
+            new ErrorMessageService().showErrorMessage(exception, "Failed to download exercises.", true);
         }
         return false;
     }

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/persistence/PersistentExerciseDatabase.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/services/persistence/PersistentExerciseDatabase.java
@@ -1,6 +1,5 @@
 package fi.helsinki.cs.tmc.intellij.services.persistence;
 
-
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/ui/projectlist/CourseTabFactory.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/ui/projectlist/CourseTabFactory.java
@@ -1,8 +1,6 @@
 package fi.helsinki.cs.tmc.intellij.ui.projectlist;
 
-
 import fi.helsinki.cs.tmc.core.domain.Exercise;
-
 import fi.helsinki.cs.tmc.intellij.holders.ProjectListManagerHolder;
 import fi.helsinki.cs.tmc.intellij.holders.TmcSettingsManager;
 import fi.helsinki.cs.tmc.intellij.io.ProjectOpener;

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/ui/projectlist/CourseTabFactory.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/ui/projectlist/CourseTabFactory.java
@@ -268,7 +268,7 @@ public class CourseTabFactory {
                 logger.warn("IOException occurred. Something interrupted "
                                 + "the mouse action. @CourseTabFactory",
                         e1, e1.getStackTrace());
-                new ErrorMessageService().showMessage(e1,
+                new ErrorMessageService().showErrorMessage(e1,
                         "IOException occurred. Something interrupted the mouse action.",
                         true);
             }
@@ -305,7 +305,7 @@ public class CourseTabFactory {
                 logger.warn("IOException occurred. Something interrupted "
                                 + "the mouse action. @CourseTabFactory",
                         e1, e1.getStackTrace());
-                new ErrorMessageService().showMessage(e1,
+                new ErrorMessageService().showErrorMessage(e1,
                         "IOException occurred. Something interrupted the mouse action.",
                         true);
             }

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/ui/projectlist/ProjectListRenderer.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/ui/projectlist/ProjectListRenderer.java
@@ -65,7 +65,7 @@ public class ProjectListRenderer extends DefaultListCellRenderer {
             }
         } catch (Exception ewr) {
 //            logger.info("Failed to set icon.", ewr, ewr.getStackTrace());
-            new ErrorMessageService().showMessage(ewr, "Failed to set icon.", true);
+            new ErrorMessageService().showErrorMessage(ewr, "Failed to set icon.", true);
         }
 
         label.setHorizontalTextPosition(JLabel.RIGHT);

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/ui/settings/SettingsPanel.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/ui/settings/SettingsPanel.java
@@ -245,7 +245,7 @@ public class SettingsPanel {
                 logger.warn("Could not list Courses from TmcCore. @SettingsPanel",
                         exception, exception.getStackTrace());
                 ErrorMessageService error = new ErrorMessageService();
-                error.showMessage((TmcCoreException) exception, true);
+                error.showHumanReadableErrorMessage((TmcCoreException) exception, true);
             }
 
             addCourSesToListOfAvailable(courses);

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/ui/settings/SettingsPanel.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/ui/settings/SettingsPanel.java
@@ -1,6 +1,5 @@
 package fi.helsinki.cs.tmc.intellij.ui.settings;
 
-
 import fi.helsinki.cs.tmc.core.domain.Course;
 import fi.helsinki.cs.tmc.core.domain.ProgressObserver;
 import fi.helsinki.cs.tmc.core.exceptions.TmcCoreException;

--- a/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/ui/submissionresult/SuccessfulSubmissionDialog.java
+++ b/tmc-plugin-intellij/src/main/java/fi/helsinki/cs/tmc/intellij/ui/submissionresult/SuccessfulSubmissionDialog.java
@@ -252,7 +252,7 @@ public class SuccessfulSubmissionDialog extends JDialog {
                             ex,
                             ex.getStackTrace());
                     new ErrorMessageService()
-                            .showMessage(ex, "Failed to open browser. Problem with browser.", true);
+                            .showErrorMessage(ex, "Failed to open browser. Problem with browser.", true);
                     String errorMessage = "Failed to open browser.\n" + ex.getMessage();
                     Messages.showErrorDialog(project, errorMessage, "Problem with Browser");
                 }


### PR DESCRIPTION
Closes #113.

The `RunResult.Status` was not being checked after running the tests, meaning that errors occurring during test compilation or running were silently being ignored. Because of this, a "Tests passed" dialog was shown even if the tests weren't even run. I'm not sure if this is a fix for #101, but this should reveal the reason of the fail to the users in the future.

This PR refactors the ErrorMessageService to some extent and adds a dialog box shown when the test run fails.

![image](https://cloud.githubusercontent.com/assets/21111572/26655692/87557eb6-4664-11e7-9b81-a4b3074d2d12.png)
